### PR TITLE
Update publications

### DIFF
--- a/src/_data/publications.json
+++ b/src/_data/publications.json
@@ -23,9 +23,9 @@
         "url": "https://doi.org/10.5194/egusphere-egu24-8752"
       },
       {
-        "venue": "EarthArXiv",
-        "title": "Wealth over Woe: global biases in hydro-hazard research",
-        "url": "https://doi.org/10.31223/X5D687"
+        "venue": "Earth's Future",
+        "title": "Wealth Over Woe: Global Biases in Hydro-Hazard Research",
+        "url": "http://dx.doi.org/10.1029/2024EF004590"
       },
       {
         "venue": "AAAI",


### PR DESCRIPTION
We already had _Wealth Over Woe: Global Biases in Hydro-Hazard Research_ as a pre-print in EarthArxiv, but today it has been finally published to the AGU journal _Earth's Future_.